### PR TITLE
Add support for the Cookie HttpOnly flag

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -41,6 +41,8 @@ type CSRF interface {
 	GetCookieName() string
 	// Return cookie path
 	GetCookiePath() string
+	// Return the flag value used for the csrf token.
+	GetCookieHttpOnly() bool
 	// Return the token.
 	GetToken() string
 	// Validate by token.
@@ -58,6 +60,8 @@ type csrf struct {
 	Cookie string
 	//Cookie path
 	CookiePath string
+	// Cookie HttpOnly flag value used for the csrf token.
+	CookieHttpOnly bool
 	// Token generated to pass via header, cookie, or hidden form value.
 	Token string
 	// This value must be unique per user.
@@ -88,6 +92,11 @@ func (c *csrf) GetCookiePath() string {
 	return c.CookiePath
 }
 
+// GetCookieHttpOnly returns the flag value used for the csrf token.
+func (c *csrf) GetCookieHttpOnly() bool {
+	return c.CookieHttpOnly
+}
+
 // GetToken returns the current token. This is typically used
 // to populate a hidden form in an HTML template.
 func (c *csrf) GetToken() string {
@@ -116,6 +125,7 @@ type Options struct {
 	Cookie string
 	// Cookie path.
 	CookiePath string
+	CookieHttpOnly bool
 	// Key used for getting the unique ID per user.
 	SessionKey string
 	// oldSeesionKey saves old value corresponding to SessionKey.
@@ -173,12 +183,13 @@ func Generate(options ...Options) macaron.Handler {
 	opt := prepareOptions(options)
 	return func(ctx *macaron.Context, sess session.Store) {
 		x := &csrf{
-			Secret:     opt.Secret,
-			Header:     opt.Header,
-			Form:       opt.Form,
-			Cookie:     opt.Cookie,
-			CookiePath: opt.CookiePath,
-			ErrorFunc:  opt.ErrorFunc,
+			Secret:         opt.Secret,
+			Header:         opt.Header,
+			Form:           opt.Form,
+			Cookie:         opt.Cookie,
+			CookiePath:     opt.CookiePath,
+			CookieHttpOnly: opt.CookieHttpOnly,
+			ErrorFunc:      opt.ErrorFunc,
 		}
 		ctx.MapTo(x, (*CSRF)(nil))
 
@@ -211,7 +222,7 @@ func Generate(options ...Options) macaron.Handler {
 			// FIXME: actionId.
 			x.Token = GenerateToken(x.Secret, x.ID, "POST")
 			if opt.SetCookie {
-				ctx.SetCookie(opt.Cookie, x.Token, 0, opt.CookiePath, "", false, true, time.Now().AddDate(0, 0, 1))
+				ctx.SetCookie(opt.Cookie, x.Token, 0, opt.CookiePath, "", false, opt.CookieHttpOnly, time.Now().AddDate(0, 0, 1))
 			}
 		}
 


### PR DESCRIPTION
Some frontend frameworks (e.g. [Angular](https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection)) need to access the CSRF token in order to use it in their requests.

The HttpOnly flag allows to set the visibility to these frameworks.

For example, a configuration that works out-of-the-box with Angular (once this PR will be merged) is:

```go
m.Use(csrf.Csrfer(csrf.Options{
        Header:         "X-XSRF-TOKEN",
        Cookie:         "XSRF-TOKEN",
        SetCookie:      true,
        CookieHttpOnly: false,
}))
```

cc @Unknwon 