### PR TITLE
Add ability to set SameSite attribute of cookie

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -137,6 +137,8 @@ type Options struct {
 	SetCookie bool
 	// Set the Secure flag to true on the cookie.
 	Secure bool
+	// Set the SameSite attribute to Lax (false) or Strict (true)
+	SameSite bool
 	// Disallow Origin appear in request header.
 	Origin bool
 	// The function called when Validate fails.
@@ -243,7 +245,7 @@ func Generate(options ...Options) macaron.Handler {
 			// FIXME: actionId.
 			x.Token = GenerateToken(x.Secret, x.ID, "POST")
 			if opt.SetCookie {
-				ctx.SetCookie(opt.Cookie, x.Token, 0, opt.CookiePath, opt.CookieDomain, opt.Secure, opt.CookieHttpOnly, time.Now().AddDate(0, 0, 1))
+				ctx.SetCookie(opt.Cookie, x.Token, 0, opt.CookiePath, opt.CookieDomain, opt.Secure, opt.CookieHttpOnly, time.Now().AddDate(0, 0, 1), opt.SameSite)
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/go-macaron/csrf
 go 1.12
 
 require (
-	github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659
+	github.com/go-macaron/session v1.0.0
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
-	github.com/unknwon/com v0.0.0-20190804042917-757f69c95f3e
-	gopkg.in/macaron.v1 v1.3.4
+	gopkg.in/macaron.v1 v1.3.4 // TODO: update once go-macaron/macaron#206 is merged
 )


### PR DESCRIPTION
Hi, 
this PR adds the ability to set the `SameSite` attribute of a cookie. 
This depends on go-macaron/macaron#206 (because I need to change the version in `go.mod`) and uses the same implementation as go-macaron/session#38.